### PR TITLE
#1000 adding  param in constructor so that the  data is passed to par…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "magento/framework": "*",
         "magento/module-deploy": "^100.3",
-        "scandipwa/route717": "^1"
+        "scandipwa/route717": "^2"
     },
     "autoload": {
         "files": [

--- a/src/View/Result/Page.php
+++ b/src/View/Result/Page.php
@@ -45,6 +45,7 @@ class Page extends OriginalPage
      * @param bool $isIsolated
      * @param EntitySpecificHandlesList|null $entitySpecificHandlesList
      * @param null $action
+     * @param array $rootTemplatePool
      */
     public function __construct(
         Resolver $localeResolver,
@@ -59,7 +60,8 @@ class Page extends OriginalPage
         string $template,
         $isIsolated = false,
         EntitySpecificHandlesList $entitySpecificHandlesList = null,
-        $action = null
+        $action = null,
+        $rootTemplatePool = []
     ) {
         parent::__construct(
             $context,
@@ -73,7 +75,8 @@ class Page extends OriginalPage
             $template,
             $isIsolated,
             $entitySpecificHandlesList,
-            $action
+            $action,
+            $rootTemplatePool
         );
 
         $this->localeResolver = $localeResolver;


### PR DESCRIPTION
…ent Page Class
ref : https://github.com/scandipwa/route717/pull/13
due to the **\ScandiPWA\Router\View\Result\Page** has been overridden by **\ScandiPWA\Locale\View\Result\Page** the **$rootTemplatePool** is passed to parent by the **\ScandiPWA\Locale\View\Result\Page**'s constructor As the root template has been passed via dependency injection
