### PR TITLE
change argument order of implode

### DIFF
--- a/src/Package/PackagePool.php
+++ b/src/Package/PackagePool.php
@@ -158,7 +158,7 @@ class PackagePool extends MagentoPackagePool
         return array_filter(
             $array,
             function ($key) use ($quotedKeysToFind, $valueCheck, $array) {
-                if (!preg_match('/(' . implode($quotedKeysToFind, '|') . ')/i', $key)) {
+                if (!preg_match('/(' . implode('|', $quotedKeysToFind) . ')/i', $key)) {
                     return false;
                 }
 


### PR DESCRIPTION
to follow the documented order,
reverse order is deprecated from php 7.4